### PR TITLE
feat: add new mask for decimal numbers

### DIFF
--- a/lib/ConfigProvider/langs/pt-br/masks/index.tsx
+++ b/lib/ConfigProvider/langs/pt-br/masks/index.tsx
@@ -3,6 +3,7 @@ import cnpj from './cnpj';
 import cpf from './cpf';
 import document from './document';
 import money from './money';
+import number from './number';
 import phone from './phone';
 import zipcode from './zipcode';
 
@@ -12,6 +13,7 @@ const masks: IMask[] = [
   { name: 'document', ...document },
   { name: 'cpf', ...cpf },
   { name: 'cnpj', ...cnpj },
-  { name: 'money', ...money }
+  { name: 'money', ...money },
+  { name: 'number', ...number }
 ];
 export default masks;

--- a/lib/ConfigProvider/langs/pt-br/masks/number.tsx
+++ b/lib/ConfigProvider/langs/pt-br/masks/number.tsx
@@ -1,0 +1,29 @@
+import 'intl';
+import 'intl/locale-data/jsonp/pt-BR';
+
+import padStart = require('lodash/padStart');
+
+import { IMaskFunction } from '../../../context';
+
+const money: IMaskFunction = {
+  apply: (value: number | string) => {
+    if (value === null || value === undefined || value === '') return '';
+    return new Intl.NumberFormat('pt-BR', { minimumFractionDigits: 2 }).format(Number(value) || 0);
+  },
+  clean: value => {
+    value = (value || '').toString().replace(/[^\d\,]/gi, '');
+
+    if (!value.includes(',')) {
+      value = '0,' + padStart(value, 2, '0');
+    }
+
+    const [, cents] = value.split(',');
+    if (cents && cents.length != 2) {
+      value = value.replace(',', '').replace(/(\d+)?(\d{2})/gi, '$1,$2').replace(/^\,/gi, '0,');
+    }
+
+    return parseFloat(value.replace(/\./gi, '').replace(',', '.'));
+  }
+};
+
+export default money;


### PR DESCRIPTION
Olá :grin: 

Eu criei uma máscara exclusiva para campos decimais, apenas uma cópia da "money" sem o cifrão.

Estou trabalhando em um projeto na WA Project que utiliza está lib e me deparei com essa necessidade.

Achei mais viável enviar um pull request adicionando essa feature :grinning: 